### PR TITLE
Fix restart with shift for qt6, add more doubleJeopardy examples

### DIFF
--- a/answer.cpp
+++ b/answer.cpp
@@ -33,6 +33,8 @@
 #include <QDebug>
 #include "answer.h"
 
+#include <algorithm> // for std::min
+
 #define stringify(x) #x
 #define FILE2(a) stringify(ui_answer_qt ## a.h)
 #define FILE(a) FILE2(a)
@@ -123,7 +125,7 @@ void Answer::updateTime()
 {
     int seconds = 31 - this->time->elapsed() / 1000;
     if(seconds >= 0)
-        ui->time->setText(QString("%1").arg(seconds, 2));
+        ui->time->setText(QString("%1").arg(std::min(30, seconds), 2));
     else
         ui->time->setText(QString("Ended..."));
 }
@@ -361,8 +363,8 @@ void Answer::keyPressEvent(QKeyEvent *event)
         {
             this->videoPlayer->stop();
             this->videoPlayer->setPosition(0);
-            QTimer::singleShot(100, ui->videoPlayer, SLOT(play()));
-            QTimer::singleShot(30000, ui->videoPlayer, SLOT(stop()));
+            QTimer::singleShot(100, this->videoPlayer, SLOT(play()));
+            QTimer::singleShot(30000, this->videoPlayer, SLOT(stop()));
         }
         else
         {
@@ -540,6 +542,8 @@ void Answer::openDoubleJeopardy()
     this->currentPlayerId = dj->getPlayer();
     this->points = dj->getPoints();
     this->doubleJeopardy = true;
+
+    this->time->restart(); // ignore selection time
 
     this->processKeypress(this->currentPlayerId);
 }

--- a/answers/1.jrf
+++ b/answers/1.jrf
@@ -31,6 +31,6 @@ Video-Examples
 Other-Examples
 100: ##comment##                        ## comment won't be shown ##
 200: [dj]answer2
-300: [dj]answer3                        ## [dj] indicates double jeopardy question ##
-400: [dj]amswer4                        ## [dj] opens menu where the player and points can be selected ##
+300: [dj][sound]1.wav                   ## [dj] indicates double jeopardy question ##
+400: [dj][video]1.mp4                   ## [dj] opens menu where the player and points can be selected ##
 500: [dj]answer5                        ## [dj] min. 50 and up to twice the points of the normal question ##


### PR DESCRIPTION
This will re-enable the restarting of the video with "shift" (useful, when video fails to load)

The timer will be reset after choosing the double jeopardy bet amount.

Fixed the timer display not to show "31" on startup (e.g. after a reset). So the first second will be longer.

Added double jeopardy examples with sound and video. Works on my machine.

Sitll open: Double jeopardy does not play the jeopardy music for "text-only" answers.

